### PR TITLE
container: add iverilog (Icarus Verilog)

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -2,7 +2,7 @@ FROM ghdl/ghdl:ubuntu20-llvm-10
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update
-RUN apt-get install -y yosys npm gtkwave scrot xvfb python3-pyvirtualdisplay python3-pip
+RUN apt-get install -y yosys iverilog npm gtkwave scrot xvfb python3-pyvirtualdisplay python3-pip
 RUN pip3 install --upgrade setuptools wheel # ubuntu 18.04 apparently doesnt have proper setuptools
 RUN pip3 install pillow pyscreenshot path
 RUN npm install -g netlistsvg


### PR DESCRIPTION
## Summary
- Adds `iverilog` (Icarus Verilog) to the apt install line of `container/Containerfile`.
- Pairs with the existing `ghdl-yosys-plugin` so the image can simulate Verilog testbenches as well as VHDL ones, from the same container.

## Why
Downstream learning projects (e.g. `naelolaiz/learning_fpga`) want to provide Verilog tutorials side-by-side with the existing VHDL examples. Today the image lacks a Verilog simulator, forcing a per-CI `apt-get install iverilog` workaround. Baking it into the image avoids that and pins the version with the rest of the toolchain.

## Test plan
- [x] Verified locally (Ubuntu 20.04 base) that `apt-get install -y iverilog` resolves cleanly to `iverilog 10.3-1build1` with 0 conflicts.
- [x] After installing in a running container, `iverilog -g2012 ...` + `vvp` produced a VCD for a small testbench, and `yosys -p 'read_verilog ...; prep -top ...; write_json ...'` synthesised a netlist — both work alongside the existing GHDL/yosys-ghdl-plugin flow.
- [ ] Rebuild the image and re-tag (`:release`) so downstream CI picks it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)