### PR TITLE
container: clone yosys with --recurse-submodules

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -12,7 +12,7 @@ RUN apt-get remove -y --purge yosys*
 
 RUN mkdir /yosys_source
 
-RUN cd /yosys_source && git clone https://github.com/YosysHQ/yosys.git && cd yosys && make -j$(nproc) && make install
+RUN cd /yosys_source && git clone --recurse-submodules https://github.com/YosysHQ/yosys.git && cd yosys && make -j$(nproc) && make install
 RUN cd /yosys_source && git clone https://github.com/ghdl/ghdl-yosys-plugin.git && cd ghdl-yosys-plugin && make -j$(nproc) && make install
 
 RUN mkdir /tools


### PR DESCRIPTION
## Summary
- Adds \`--recurse-submodules\` to the \`git clone\` of YosysHQ/yosys in \`container/Containerfile\`.

## Why
The image build that ran right after #3 merged failed at the yosys-from-source step (run [24861944784](https://github.com/naelolaiz/hdltools/actions/runs/24861944784)):

\`\`\`
Initialize the submodule: Run 'git submodule update --init' to set up 'abc' as a submodule.
make: *** [Makefile:852: check-git-abc] Error 1
fatal error: libs/cxxopts/include/cxxopts.hpp: No such file or directory
\`\`\`

Recent yosys requires the \`abc\` and \`libs/cxxopts\` submodules to be present at clone time. The ghdl-yosys-plugin line below doesn't have submodules today, so only the yosys clone needs the flag.

## Test plan
- [ ] CI rebuilds the image to ghcr.io/naelolaiz/hdltools:release.
- [ ] Downstream learning_fpga CI continues to work against the new image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)