### PR TITLE
ci: bump docker-image.yml actions to Node 24 versions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
-        
+        uses: actions/checkout@v5
+
       #- name: Log in to the Container registry
-      #  uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      #  uses: docker/login-action@v3
       #  with:
       #    registry: ${{ env.REGISTRY }}
       #    username: ${{ github.actor }}
@@ -37,12 +37,12 @@ jobs:
 
       #- name: Extract metadata (tags, labels) for Docker
       #  id: meta
-      #  uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+      #  uses: docker/metadata-action@v5
       #  with:
       #    images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v6
         with:
           context: .
           file: container/Containerfile


### PR DESCRIPTION
## Summary

Silences the `save-state` / `set-output` deprecation warnings on every CI run and future-proofs against the Node 24 enforcement coming 2026-06-02.

- `actions/checkout@v3` (Node 16) → `@v5` (Node 24). v3 is the source of the `save-state`/`set-output` deprecation warnings in every run log.
- `docker/build-push-action@ad44023…` (2022 SHA, Node 16) → `@v6` (Node 20+; will move to Node 24 automatically).
- Updated the commented-out `login-action` / `metadata-action` examples to `@v3` / `@v5` so they don't come back stale if someone un-comments them later.

## Test plan

- [ ] GitHub Actions `docker-image.yml` run is green on this branch and the CI log no longer contains `save-state` / `set-output` deprecation warnings or `Node.js 20 actions are deprecated` warnings for these two actions.