### PR TITLE
ci: actually push the docker image to ghcr

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -22,30 +22,37 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      #packages: write
+      packages: write
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      #- name: Log in to the Container registry
-      #  uses: docker/login-action@v3
-      #  with:
-      #    registry: ${{ env.REGISTRY }}
-      #    username: ${{ github.actor }}
-      #    password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      #- name: Extract metadata (tags, labels) for Docker
-      #  id: meta
-      #  uses: docker/metadata-action@v5
-      #  with:
-      #    images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Every push to main updates :latest and :release so downstream
+          # repos pinning :release actually get new builds, plus a
+          # content-addressed :sha-<SHA> tag for reproducibility.
+          tags: |
+            type=raw,value=latest
+            type=raw,value=release
+            type=sha,prefix=sha-
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
           context: .
           file: container/Containerfile
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
The image-build workflow has had \`push: false\` (plus the login / tagging / \`packages:write\` permission steps commented out) since it landed. So every successful run has been a build-only no-op. The \`ghcr.io/naelolaiz/hdltools:release\` tag has not been updated since 2022 — downstream consumers pinning \`:release\` have been pulling that 2022 image the whole time, which is why recent Containerfile changes (iverilog, libfl-dev, \`--recurse-submodules\`, pinned plugin) never took effect anywhere outside the build runner.

## Changes
- \`permissions: packages: write\` — so the job can actually push to ghcr.
- \`docker/login-action\` against ghcr using the built-in \`GITHUB_TOKEN\`.
- \`docker/metadata-action\` generating three tags per \`main\` push: \`:latest\`, \`:release\`, and \`:sha-<commit>\` (content-addressed, handy for anyone who wants a pin that doesn't move).
- \`push: true\` on the build step so the tags land on the registry.

## Test plan
- [ ] Merge and let the workflow run. Confirm new versions appear at ghcr.io/naelolaiz/hdltools under \`:release\` and \`:latest\`.
- [ ] \`podman pull ghcr.io/naelolaiz/hdltools:release\` — the pulled image should include every tool in the current Containerfile runtime stage (ghdl, yosys, ghdl-yosys-plugin, netlistsvg, iverilog, gtkwave, xvfb, python3-pil, ...).
- [ ] Downstream learning_fpga CI works without an in-workflow \`apt-get install iverilog\` bridge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)