### PR TITLE
container: restore runtime toolchain (make, cmake, build tools)

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -32,6 +32,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
+      build-essential cmake git pkg-config patch xz-utils \
+      tcl bison flex \
       gtkwave iverilog scrot xvfb \
       nodejs npm \
       python3 python3-pil python3-pip \


### PR DESCRIPTION
## Summary

Fixes `make: command not found` in the published image — Makefile-driven workflows (e.g. learning_fpga CI) broke after the multi-stage cleanup in #6/#7 because all build deps moved to the throwaway builder stage.

Audited the pre-cleanup image's tool inventory and restored what was actually there plus `cmake`:

| Package | Why |
|---|---|
| `build-essential` | restores `make` (gcc was already in the base; pulls g++ + dpkg-dev too) |
| `cmake` | requested |
| `git` | clone deps from inside the image |
| `pkg-config` | build configs |
| `patch` | common for build systems |
| `xz-utils` | `tar.xz` handling |
| `tcl` | provides `tclsh` (useful with yosys scripts) |
| `bison`, `flex` | parity with pre-cleanup image |

**Skipped** (intentionally): `clang` — ~500 MB of bulk that duplicates gcc/g++ functionally. Ask if you want it back.

## Verification

`podman build -t hdltools:test -f container/Containerfile .` succeeds locally. Inventory in the built image:

```
[ok] make       GNU Make 4.3
[ok] cmake      cmake version 3.22.1
[ok] git        git version 2.34.1
[ok] gcc / g++ / ld / pkg-config / bison / flex
[ok] tclsh / patch / xz / python3 / perl
```

Image size: **1.03 GB → 1.13 GB** (+100 MB).

## Test plan

- [x] `podman build` succeeds locally.
- [x] `make --version`, `cmake --version`, `git --version` all run inside the built image.
- [ ] GitHub Actions `docker-image.yml` is green on this branch.
- [ ] downstream `learning_fpga` CI (which consumes `ghcr.io/naelolaiz/hdltools:release`) runs `make` successfully.

## Follow-up candidate (not in this PR)

`npm` and `python3-pip` only exist in the runtime image to install `netlistsvg` / Python packages at build time; both could be purged at the end of the RUN layer to shave ~30-50 MB. Happy to open a separate PR if you want that.