### PR TITLE
container: add SystemVerilog toolchain (iverilog v13, Verilator v5, slang v10)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,9 +83,9 @@ jobs:
                      ghdl yosys iverilog vvp verilator slang netlistsvg waveview; do
               command -v "$t" >/dev/null || { echo "MISSING: $t"; exit 1; }
             done
-            # iverilog must be at least v12 (built from source); the apt
-            # v11 has limited FST output and won't accept "vvp <vvp> -fst"
-            # extended args. Guard against a silent fallback to apt.
+            # iverilog must be at least v12 (built from source); apt v11
+            # has limited FST output and rejects the "vvp <vvp> -fst"
+            # extended-arg form. Guard against a silent fallback to apt.
             iverilog -V 2>&1 | head -1 | grep -qE "version 1[2-9]" \
               || { iverilog -V; echo "iverilog is older than v12"; exit 1; }
             # Verilator must be v5.x (the SV-2017 verification subset

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -80,9 +80,41 @@ jobs:
             set -e
             for t in make cmake gcc g++ git pkg-config bison flex patch xz \
                      tar awk sed find python3 perl \
-                     ghdl yosys iverilog netlistsvg waveview; do
+                     ghdl yosys iverilog vvp verilator slang netlistsvg waveview; do
               command -v "$t" >/dev/null || { echo "MISSING: $t"; exit 1; }
             done
+            # iverilog must be v12 (built from source); the apt v11 has
+            # limited FST output. Guard against the source build silently
+            # falling back to the apt package.
+            iverilog -V 2>&1 | head -1 | grep -qE "version 12" \
+              || { iverilog -V; echo "iverilog is not v12"; exit 1; }
+            # Verilator must be v5.x (the SV-2017 verification subset
+            # support landed in 5.x; 4.x would silently miss many
+            # constructs the SV smoke fixture exercises).
+            verilator --version 2>&1 | head -1 | grep -qE "Verilator 5" \
+              || { verilator --version; echo "verilator is not v5.x"; exit 1; }
+          '
+
+          # 1b. iverilog FST output: compile the fixture, run under vvp, and
+          # confirm a non-empty FST file appeared. Catches FST regressions
+          # when the iverilog version is bumped.
+          docker run --rm -v "$PWD/container/test:/test:ro" "$IMG" bash -c '
+            set -e
+            cd /tmp
+            cp /test/fst_smoke.v .
+            iverilog -o fst_smoke.vvp fst_smoke.v
+            vvp -fst fst_smoke.vvp
+            test -s smoke.fst
+          '
+
+          # 1c. SystemVerilog: Verilator and slang must both lint a
+          # non-trivial SV-2017 design (typedef, packed struct, always_ff,
+          # struct literals). Catches a v5/v4 verilator slip or a missing
+          # slang install in the runtime image.
+          docker run --rm -v "$PWD/container/test:/test:ro" "$IMG" bash -c '
+            set -e
+            verilator --lint-only --top sv_smoke /test/sv_smoke.sv
+            slang --top sv_smoke /test/sv_smoke.sv
           '
 
           # 2. waveview imports cleanly (catches missing pywellen/pycairo/yaml).

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -83,11 +83,11 @@ jobs:
                      ghdl yosys iverilog vvp verilator slang netlistsvg waveview; do
               command -v "$t" >/dev/null || { echo "MISSING: $t"; exit 1; }
             done
-            # iverilog must be v12 (built from source); the apt v11 has
-            # limited FST output. Guard against the source build silently
-            # falling back to the apt package.
-            iverilog -V 2>&1 | head -1 | grep -qE "version 12" \
-              || { iverilog -V; echo "iverilog is not v12"; exit 1; }
+            # iverilog must be at least v12 (built from source); the apt
+            # v11 has limited FST output and won't accept "vvp <vvp> -fst"
+            # extended args. Guard against a silent fallback to apt.
+            iverilog -V 2>&1 | head -1 | grep -qE "version 1[2-9]" \
+              || { iverilog -V; echo "iverilog is older than v12"; exit 1; }
             # Verilator must be v5.x (the SV-2017 verification subset
             # support landed in 5.x; 4.x would silently miss many
             # constructs the SV smoke fixture exercises).
@@ -95,16 +95,23 @@ jobs:
               || { verilator --version; echo "verilator is not v5.x"; exit 1; }
           '
 
-          # 1b. iverilog FST output: compile the fixture, run under vvp, and
-          # confirm a non-empty FST file appeared. Catches FST regressions
-          # when the iverilog version is bumped.
+          # 1b. iverilog FST output: compile the fixture, run under vvp,
+          # confirm the dump is in FST format (not just a .fst-named VCD).
+          # The -fst flag is an *extended argument* and must come AFTER
+          # the input .vvp file; if it comes before, vvp parses it as a
+          # short-option group (-f -s -t) and rejects -f / -t.
           docker run --rm -v "$PWD/container/test:/test:ro" "$IMG" bash -c '
             set -e
             cd /tmp
             cp /test/fst_smoke.v .
             iverilog -o fst_smoke.vvp fst_smoke.v
-            vvp -fst fst_smoke.vvp
+            vvp fst_smoke.vvp -fst
             test -s smoke.fst
+            # FST is binary; VCD starts with "$date". Catch a silent
+            # fallback to VCD-with-.fst-extension.
+            if head -c 100 smoke.fst | grep -q "\$date"; then
+              echo "FAIL: smoke.fst is VCD, not FST"; exit 1
+            fi
           '
 
           # 1c. SystemVerilog: Verilator and slang must both lint a

--- a/README.md
+++ b/README.md
@@ -10,13 +10,19 @@ paper over missing features in the underlying tools.
 | [GHDL](https://github.com/ghdl/ghdl) | VHDL analysis, elaboration, simulation |
 | [Yosys](https://github.com/YosysHQ/yosys) | RTL synthesis (built from source) |
 | [ghdl-yosys-plugin](https://github.com/ghdl/ghdl-yosys-plugin) | Lets Yosys read VHDL via GHDL (built from source) |
-| [Icarus Verilog](https://github.com/steveicarus/iverilog) | Verilog simulation |
+| [Icarus Verilog](https://github.com/steveicarus/iverilog) | Verilog simulation (v12, built from source — Ubuntu 22.04 apt is stuck on v11 which has weak FST support) |
+| [Verilator](https://github.com/verilator/verilator) | SystemVerilog 2017 simulator (v5.x, built from source — best-of-class open-source SV simulator; cycle-accurate, compiles SV → C++) |
+| [slang](https://github.com/MikePopoloski/slang) | SystemVerilog 2017 parser/elaborator/linter (v10.x, built from source — modern, fast, and the front-end for the yosys-slang synthesis path) |
 | [netlistsvg](https://github.com/nturley/netlistsvg) | Render Yosys JSON netlists as SVG |
 | [pywellen](https://github.com/ekiwi/wellen) + [pycairo](https://pycairo.readthedocs.io/) | Parser + renderer used by `waveview` |
 
 Yosys and the GHDL plugin are compiled from `git` because the Debian/Ubuntu
 packaged Yosys is too old for the plugin
 (see [ghdl-yosys-plugin#149](https://github.com/ghdl/ghdl-yosys-plugin/issues/149)).
+Icarus Verilog, Verilator, and slang are also built from source: apt's
+`iverilog` predates the FST output rework, apt's `verilator` is too old
+for the SystemVerilog 2017 verification subset, and `slang` isn't packaged
+on Ubuntu 22.04 at all.
 
 ## Helper scripts
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ paper over missing features in the underlying tools.
 | [GHDL](https://github.com/ghdl/ghdl) | VHDL analysis, elaboration, simulation |
 | [Yosys](https://github.com/YosysHQ/yosys) | RTL synthesis (built from source) |
 | [ghdl-yosys-plugin](https://github.com/ghdl/ghdl-yosys-plugin) | Lets Yosys read VHDL via GHDL (built from source) |
-| [Icarus Verilog](https://github.com/steveicarus/iverilog) | Verilog simulation (v12, built from source — Ubuntu 22.04 apt is stuck on v11 which has weak FST support) |
+| [Icarus Verilog](https://github.com/steveicarus/iverilog) | Verilog simulation (v13, built from source — Ubuntu 22.04 apt is stuck on v11 which doesn't accept the `vvp <vvp> -fst` extended-arg form needed for FST output) |
 | [Verilator](https://github.com/verilator/verilator) | SystemVerilog 2017 simulator (v5.x, built from source — best-of-class open-source SV simulator; cycle-accurate, compiles SV → C++) |
 | [slang](https://github.com/MikePopoloski/slang) | SystemVerilog 2017 parser/elaborator/linter (v10.x, built from source — modern, fast, and the front-end for the yosys-slang synthesis path) |
 | [netlistsvg](https://github.com/nturley/netlistsvg) | Render Yosys JSON netlists as SVG |

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -26,6 +26,83 @@ RUN git clone https://github.com/ghdl/ghdl-yosys-plugin.git \
  && make -C ghdl-yosys-plugin install
 
 
+# ---- Build Icarus Verilog v12 from source ----
+# Ubuntu 22.04 apt ships iverilog 11.0, which has limited FST output support.
+# v12 makes FST a first-class dump format and fixes a number of $dumpfile /
+# $dumpvars edge cases. Pinned to the v12_0 release tag for reproducibility.
+# Built on plain ubuntu:22.04 (matching the runtime base's libc/libstdc++) so
+# the resulting binaries drop straight into the runtime image.
+FROM docker.io/library/ubuntu:22.04 AS iverilog-builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates git build-essential autoconf gperf bison flex \
+      libreadline-dev zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG IVERILOG_REF=v12_0
+WORKDIR /src
+RUN git clone --depth 1 --branch "$IVERILOG_REF" \
+      https://github.com/steveicarus/iverilog.git \
+ && cd iverilog \
+ && sh autoconf.sh \
+ && ./configure --prefix=/opt/iverilog \
+ && make -j"$(nproc)" \
+ && make install
+
+
+# ---- Build Verilator from source ----
+# The only mature open-source SystemVerilog simulator. v5.x has solid
+# support for SV-2017's synthesizable subset plus much of the verification
+# subset (interfaces, packages, packed structs, classes-lite). Pinned to
+# the v5.048 release tag for reproducibility — bump to upgrade.
+FROM docker.io/library/ubuntu:22.04 AS verilator-builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates git build-essential autoconf bison flex \
+      perl python3 help2man libfl-dev libfl2 zlib1g-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG VERILATOR_REF=v5.048
+WORKDIR /src
+RUN git clone --depth 1 --branch "$VERILATOR_REF" \
+      https://github.com/verilator/verilator.git \
+ && cd verilator \
+ && autoconf \
+ && ./configure --prefix=/opt/verilator \
+ && make -j"$(nproc)" \
+ && make install
+
+
+# ---- Build slang from source ----
+# Modern SystemVerilog 2017 parser/elaborator/linter. Best-in-class
+# conformance and very fast — useful as a standalone lint pass and as
+# the front-end yosys-slang plugs into for SV synthesis. Needs CMake
+# >= 3.20 and gcc >= 11; ubuntu 22.04 ships 3.22.1 / 11.4 so the default
+# toolchain is enough.
+FROM docker.io/library/ubuntu:22.04 AS slang-builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      ca-certificates git build-essential cmake python3 \
+ && rm -rf /var/lib/apt/lists/*
+
+ARG SLANG_REF=v10.0
+WORKDIR /src
+RUN git clone --depth 1 --branch "$SLANG_REF" \
+      https://github.com/MikePopoloski/slang.git \
+ && cmake -S slang -B slang/build \
+      -DCMAKE_BUILD_TYPE=Release \
+      -DCMAKE_INSTALL_PREFIX=/opt/slang \
+      -DSLANG_INCLUDE_TESTS=OFF \
+ && cmake --build slang/build --parallel "$(nproc)" \
+ && cmake --install slang/build --strip
+
+
 # ---- Runtime image ----
 FROM docker.io/ghdl/ghdl:6.0.0-llvm-ubuntu-22.04
 ENV DEBIAN_FRONTEND=noninteractive
@@ -42,8 +119,8 @@ RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       build-essential cmake git pkg-config patch xz-utils \
       tcl bison flex \
-      iverilog \
       nodejs npm \
+      perl \
       python3 python3-pip python3-cairo python3-yaml \
       fonts-dejavu-core \
       libfl2 libreadline8 libtcl8.6 \
@@ -56,6 +133,11 @@ RUN apt-get update \
 
 COPY --from=yosys-builder /usr/local/bin/yosys* /usr/local/bin/
 COPY --from=yosys-builder /usr/local/share/yosys/ /usr/local/share/yosys/
+
+COPY --from=iverilog-builder /opt/iverilog/ /opt/iverilog/
+COPY --from=verilator-builder /opt/verilator/ /opt/verilator/
+COPY --from=slang-builder /opt/slang/ /opt/slang/
+ENV PATH=/opt/iverilog/bin:/opt/verilator/bin:/opt/slang/bin:$PATH
 
 COPY vhd2svg.sh /tools/
 COPY waveview/ /tools/waveview/

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -26,12 +26,13 @@ RUN git clone https://github.com/ghdl/ghdl-yosys-plugin.git \
  && make -C ghdl-yosys-plugin install
 
 
-# ---- Build Icarus Verilog v12 from source ----
-# Ubuntu 22.04 apt ships iverilog 11.0, which has limited FST output support.
-# v12 makes FST a first-class dump format and fixes a number of $dumpfile /
-# $dumpvars edge cases. Pinned to the v12_0 release tag for reproducibility.
-# Built on plain ubuntu:22.04 (matching the runtime base's libc/libstdc++) so
-# the resulting binaries drop straight into the runtime image.
+# ---- Build Icarus Verilog from source ----
+# Ubuntu 22.04 apt ships iverilog 11.0; we want FST waveform output via
+# `vvp <design>.vvp -fst`, which needs the system.vpi extended-arg
+# parser shipped in v12.0+ and is the default output recommendation for
+# GTKWave / Surfer. Pinned to v13_0 (stable, March 2026). Built on plain
+# ubuntu:22.04 to match the runtime base's libc/libstdc++ so the
+# resulting binaries drop straight into the runtime image.
 FROM docker.io/library/ubuntu:22.04 AS iverilog-builder
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -41,7 +42,7 @@ RUN apt-get update \
       libreadline-dev zlib1g-dev \
  && rm -rf /var/lib/apt/lists/*
 
-ARG IVERILOG_REF=v12_0
+ARG IVERILOG_REF=v13_0
 WORKDIR /src
 RUN git clone --depth 1 --branch "$IVERILOG_REF" \
       https://github.com/steveicarus/iverilog.git \

--- a/container/test/fst_smoke.v
+++ b/container/test/fst_smoke.v
@@ -1,0 +1,12 @@
+// Minimal Verilog used by the CI smoke test to verify that the iverilog v12
+// build produces working FST output. Toggles a register a few times and
+// dumps to smoke.fst via $dumpfile.
+module fst_smoke;
+  reg clk = 0;
+  initial begin
+    $dumpfile("smoke.fst");
+    $dumpvars(0, fst_smoke);
+    repeat (4) #5 clk = ~clk;
+    $finish;
+  end
+endmodule

--- a/container/test/sv_smoke.sv
+++ b/container/test/sv_smoke.sv
@@ -1,0 +1,30 @@
+// SystemVerilog fixture used by the CI smoke test to confirm that
+// Verilator and slang can both lint a non-trivial SV-2017 design.
+// Exercises features that don't exist in plain Verilog-2005:
+// `logic`, `typedef struct packed`, struct literals, `always_ff`,
+// parameterised `int` widths, default port directions.
+typedef struct packed {
+  logic       valid;
+  logic [7:0] data;
+} entry_t;
+
+module sv_smoke #(
+  parameter int W = 8
+) (
+  input  logic              clk,
+  input  logic              rst_n,
+  input  logic [W-1:0]      d,
+  output logic [W-1:0]      q
+);
+  entry_t s;
+
+  always_ff @(posedge clk or negedge rst_n) begin
+    if (!rst_n) begin
+      s <= '{valid: 1'b0, data: '0};
+      q <= '0;
+    end else begin
+      s <= '{valid: 1'b1, data: d};
+      q <= s.data;
+    end
+  end
+endmodule

--- a/container/test/sv_smoke.sv
+++ b/container/test/sv_smoke.sv
@@ -1,8 +1,7 @@
-// SystemVerilog fixture used by the CI smoke test to confirm that
-// Verilator and slang can both lint a non-trivial SV-2017 design.
-// Exercises features that don't exist in plain Verilog-2005:
-// `logic`, `typedef struct packed`, struct literals, `always_ff`,
-// parameterised `int` widths, default port directions.
+// SystemVerilog fixture used by the CI smoke test. Exercises features
+// that don't exist in plain Verilog-2005: logic, typedef struct packed,
+// struct literals, always_ff, parameterised int widths, default port
+// directions. Both linters lint this in CI.
 typedef struct packed {
   logic       valid;
   logic [7:0] data;


### PR DESCRIPTION
## Summary

- **Icarus Verilog v13_0** (stable, March 2026) — apt's v11 doesn't accept the `vvp <vvp> -fst` extended-arg form needed for FST waveform output (the recommended GTKWave / Surfer path)
- **Verilator v5.048** — apt v4.x silently drops many SV-2017 constructs; v5 covers the synthesizable subset + most of the verification subset
- **slang v10.0** — modern SV-2017 parser/elaborator/linter, not packaged on Ubuntu 22.04 at all; also the front-end the yosys-slang plugin builds against

Each tool builds in its own `ubuntu:22.04` stage matching the runtime base's libc/libstdc++ and installs into `/opt/<name>/`. Bump tags via `IVERILOG_REF` / `VERILATOR_REF` / `SLANG_REF` build-args. Runtime gains `perl` (Verilator's driver is a perl script).

## CI smoke additions

- presence checks for `vvp`, `verilator`, `slang`
- version gates: `iverilog -V` must report v12 or higher (regex `version 1[2-9]`), `verilator --version` must report v5 — guards against a silent fallback to apt
- iverilog FST round-trip from a tiny Verilog fixture, with a "not VCD" magic-byte guard so a silent VCD-named-`.fst` fallback fails the gate
- SV-2017 lint via both Verilator and slang of a typedef + packed-struct + always_ff fixture

## Notes for reviewers / future-self

- `vvp -fst` is an **extended argument** that goes AFTER the input `.vvp`; putting it before makes vvp parse it as the short-option group `-f -s -t` and reject `-f` / `-t`. The first CI run on this PR hit exactly that.
- Verilator's pragma scanner picks up the literal substring `/*verilator` even inside `//` line comments. The SV smoke fixture deliberately doesn't mention either tool name in a way that could trip BADVLTPRAGMA.

## Test plan

- [x] full smoke run locally with podman against the rebuilt image (iverilog 13.0, Verilator 5.048, slang 10.0): tool presence + version, FST round-trip, SV lint by both tools, waveview SVG + PNG, yosys+ghdl synth — all green
- [x] CI green on the PR
- [ ] downstream consumers can `verilator --lint-only foo.sv` and `slang foo.sv` directly on the published `:release` image