### PR TITLE
container: install hierarchical netlistsvg in the default image

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,8 @@ name: Create and publish a Docker image
 
 on:
   push:
-    branches: ['main']
+    branches:
+      - '**'
   pull_request:
     paths:
       - 'container/**'
@@ -52,12 +53,13 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # Every push to main updates :latest and :release so downstream
-          # repos pinning :release actually get new builds, plus a
-          # content-addressed :sha-<SHA> tag for reproducibility.
+          # Every branch push publishes a branch-derived tag. The default
+          # branch also updates :latest and :release.
+          # All pushed images also get a content-addressed :sha-<SHA> tag.
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=raw,value=release,enable={{is_default_branch}}
+            type=ref,event=branch,enable=${{ github.event_name == 'push' }}
             type=sha,prefix=sha-
 
       - name: Build image for testing (not pushed)
@@ -156,7 +158,7 @@ jobs:
             test -s /tmp/out/ping.json
           '
 
-      - name: Push image (only on push to main)
+      - name: Push image (only on configured push branches)
         if: github.event_name == 'push'
         uses: docker/build-push-action@v7
         with:
@@ -166,3 +168,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
+

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ to `main` (see
 | --- | --- |
 | `ghcr.io/naelolaiz/hdltools:latest`  | latest build from `main` (rolling) |
 | `ghcr.io/naelolaiz/hdltools:release` | same as `latest`; what downstream repos pin to |
+| `ghcr.io/naelolaiz/hdltools:<branch>` | branch-derived test image for each pushed branch; invalid Docker tag characters are normalized by `docker/metadata-action` |
 | `ghcr.io/naelolaiz/hdltools:sha-<short>` | content-addressed per commit |
 | `ghcr.io/naelolaiz/hdltools:vcd2png` | **legacy backup** — last image that still bundled the GTKWave/Xvfb-based `vcd2png.py` (commit `a146717`). Kept as a parking spot for anyone still pinning to that pipeline. New work uses `:release` and the `waveview` tool inside it. |
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -107,6 +107,10 @@ RUN git clone --depth 1 --branch "$SLANG_REF" \
 # ---- Runtime image ----
 FROM docker.io/ghdl/ghdl:6.0.0-llvm-ubuntu-22.04
 ENV DEBIAN_FRONTEND=noninteractive
+# Install netlistsvg from the hierarchical fork — gives clickable
+# submodule drilldown pages with external port markers. Pinned to the
+# tagged snapshot so bumps are deliberate.
+ARG NETLISTSVG_REF=hierarchy-drilldown-v1
 
 # libghdl has its std/ieee path baked in from GHDL's own CI build
 # (/home/runner/work/ghdl/ghdl/...) so the yosys -m ghdl pipeline can't
@@ -128,7 +132,7 @@ RUN apt-get update \
  && pip3 install --no-cache-dir --upgrade pip setuptools wheel \
  && pip3 install --no-cache-dir \
       'pywellen ~= 0.20' \
- && npm install -g --no-fund --no-audit netlistsvg \
+ && npm install -g --no-fund --no-audit "git+https://github.com/naelolaiz/netlistsvg.git#$NETLISTSVG_REF" \
  && npm cache clean --force \
  && rm -rf /var/lib/apt/lists/* /root/.npm /root/.cache
 


### PR DESCRIPTION
## Summary

Switch the hdltools default image to install netlistsvg from the
hierarchical fork (naelolaiz/netlistsvg, tag `hierarchy-drilldown-v1`)
instead of the npm registry build, and publish a per-branch image
tag for every pushed branch so downstream repos can pin to a specific
build for testing.

After merge: `ghcr.io/naelolaiz/hdltools:latest` and `:release` ship
with the hierarchical netlistsvg, so downstream renders pick up the
clickable submodule drilldown pages automatically.

## Test plan

- [ ] CI smoke suite passes (yosys+ghdl synthesis, iverilog/verilator/
  slang lint, waveview render).
- [ ] Image build pulls netlistsvg from the pinned tag.
- [ ] Render a hierarchical Yosys JSON inside the published image and
  confirm drilldown pages carry external `inputExt` / `outputExt` port
  markers.
